### PR TITLE
Dailymotion shortcode: fix failing test.

### DIFF
--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -196,20 +196,21 @@ function dailymotion_shortcode( $atts ) {
 
 	$id = urlencode( $id );
 
+	$output = '';
+
 	if ( preg_match( '/^[A-Za-z0-9]+$/', $id ) ) {
-		$output = '<iframe width="' . $width . '" height="' . $height . '" src="' . esc_url( $video_url ) . '" frameborder="0"></iframe>';
-		$after  = '';
+		$output .= '<iframe width="' . $width . '" height="' . $height . '" src="' . esc_url( $video_url ) . '" frameborder="0"></iframe>';
 
 		if ( array_key_exists( 'video', $atts ) && $video = preg_replace( '/[^-a-z0-9_]/i', '', $atts['video'] ) && array_key_exists( 'title', $atts ) && $title = wp_kses( $atts['title'], array() ) ) {
-			$after .= '<br /><strong><a href="' . esc_url( 'http://www.dailymotion.com/video/' . $video ) . '" target="_blank">' . esc_html( $title ) . '</a></strong>';
+			$output .= '<br /><strong><a href="' . esc_url( 'http://www.dailymotion.com/video/' . $video ) . '" target="_blank">' . esc_html( $title ) . '</a></strong>';
 		}
 
 		if ( array_key_exists( 'user', $atts ) && $user = preg_replace( '/[^-a-z0-9_]/i', '', $atts['user'] ) ) {
-			$after .= '<br /><em>Uploaded by <a href="' . esc_url( 'http://www.dailymotion.com/' . $user ) . '" target="_blank">' . esc_html( $user ) . '</a></em>';
+			$output .= '<br /><em>Uploaded by <a href="' . esc_url( 'http://www.dailymotion.com/' . $user ) . '" target="_blank">' . esc_html( $user ) . '</a></em>';
 		}
 	}
 
-	return $output . $after;
+	return $output;
 }
 
 add_shortcode( 'dailymotion', 'dailymotion_shortcode' );


### PR DESCRIPTION
@see https://travis-ci.org/Automattic/jetpack/jobs/146048719
- $output should always be defined to avoid issues.
- Let's get rid of $after, since we can append the strings to $output instead of using 2 variables.
