### PR TITLE
Dailymotion shortcode: fix failing test when ID is an empty string

### DIFF
--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -124,7 +124,7 @@ function dailymotion_shortcode( $atts ) {
 		}
 	}
 
-	if ( isset( $atts['id'] ) ) {
+	if ( isset( $atts['id'] ) && ! empty( $atts['id'] ) ) {
 		$id = $atts['id'];
 	} else {
 		return '<!--Dailymotion error: bad or missing ID-->';


### PR DESCRIPTION
One last failing test. I should have ran the tests locally before to send my last pull request, sorry!
